### PR TITLE
fix: /bin/sh doesnt exist on erpc base image

### DIFF
--- a/Dockerfile.erpc
+++ b/Dockerfile.erpc
@@ -1,18 +1,25 @@
-# Base image
-FROM ghcr.io/erpc/erpc:latest
+# Build stage
+FROM alpine:latest as builder
 
 # Install gomplate for advanced templating
 RUN apk add --no-cache curl && \
     curl -L https://github.com/hairyhenderson/gomplate/releases/download/v3.11.3/gomplate_linux-amd64 -o /usr/local/bin/gomplate && \
     chmod +x /usr/local/bin/gomplate
 
-# Set environment variables (these can be empty or set by your CI/CD environment)
-ENV ALCHEMY_API_KEY=""
-ENV BLASTAPI_API_KEY=""
-ENV DRPC_API_KEY=""
-
-# Copy the template config
+# Copy and process config in build stage
 COPY erpc.yaml /root/erpc.yaml.template
+RUN gomplate -f /root/erpc.yaml.template -o /root/erpc.yaml
 
-# Generate the final config file at runtime
-CMD gomplate -f /root/erpc.yaml.template -o /root/erpc.yaml && ./erpc-server
+# Final stage
+FROM ghcr.io/erpc/erpc:latest
+
+# Set environment variables (these can be empty or set by your CI/CD environment)
+ENV ALCHEMY_API_KEY="" \
+    BLASTAPI_API_KEY="" \
+    DRPC_API_KEY=""
+
+# Copy processed config from builder
+COPY --from=builder /root/erpc.yaml /root/erpc.yaml
+
+# Run server
+CMD ["./erpc-server"]


### PR DESCRIPTION
Adds a build stage with shell support (w Alpine) to execute necessary commands, resolving the Railway template build failure caused by this: https://github.com/erpc/erpc/commit/71cf4062b6d470fdf76c02911ec0a56d3f89a3c0#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R42